### PR TITLE
Documentation extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@
 # Logs
 npm-debug.log
 yarn-error.log
+
+# IDEs
+.idea/
+.vscode/
+
+# Operating system
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [[5.0.0] - 2022-04-26](https://github.com/monooso/unobserve/releases/tag/v5.0.0)
+### Added
+- Support for Laravel 9
+
 ## [[4.0.0] - 2021-05-24](https://github.com/monooso/unobserve/releases/tag/v4.0.0)
 ### Added
 - Support for PHP 8

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ UserObserver::unmute();
 
 ## Mute options
 
-Mute all events of the observer:
+Mute all observer events:
 
 ```php
 UserObserver::mute();
 ```
 
-Mute only specific events from the observer:
+Mute specific observer events:
 
 ```php
 UserObserver::mute('creating');

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unobserve
 
 <p>
-  <img src="https://github.com/monooso/unobserve/actions/workflows/lint-and-test.yml/badge.svg" alt="Lint and Test Status"/></a>
+  <a href="https://github.com/monooso/unobserve/actions/workflows/lint-and-test.yml"><img src="https://github.com/monooso/unobserve/actions/workflows/lint-and-test.yml/badge.svg" alt="Lint and Test Status"/></a>
   <a href="https://scrutinizer-ci.com/g/monooso/unobserve"><img src="https://img.shields.io/scrutinizer/g/monooso/unobserve.svg" alt="Quality Score"/></a>
   <a href="https://scrutinizer-ci.com/g/monooso/unobserve"><img src="https://img.shields.io/scrutinizer/coverage/g/monooso/unobserve.svg" alt="Coverage"/></a>
   <a href="https://packagist.org/packages/monooso/unobserve"><img src="https://poser.pugx.org/monooso/unobserve/v/stable.svg" alt="Latest Stable Version"/></a>

--- a/README.md
+++ b/README.md
@@ -53,5 +53,20 @@ UserObserver::mute();
 UserObserver::unmute();
 ```
 
+## Mute options
+
+Mute all events of the observer:
+
+```php
+UserObserver::mute();
+```
+
+Mute only specific events from the observer:
+
+```php
+UserObserver::mute('creating');
+UserObserver::mute(['creating', 'created']);
+```
+
 ## License
 Unobserve is open source software, released under [the MIT license](https://github.com/monooso/unobserve/blob/master/LICENSE.txt).


### PR DESCRIPTION
Changes:
- described the mute possibility to mute only specific events of the observer
- adjust badge link directly to related workflow (the opening 'a href' tag was missing)
- added changelog for 5.x
- extended .gitignore

Thank you for that awesome package.
I was searching for the possibility to disable only the 'created' event of my observer.
Found your package and inside of it the hidden feature that I was looking for.
Would like to point out this feature in the documentation.

If you have any suggestions about my changes let me know.
