### PR TITLE
changed resolve of the muted class to allow constructor injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [[X.X.X] - 2022-05-26](https://github.com/monooso/unobserve/releases/tag/vX.X.X)
+### Changed
+- changed resolve of the muted class to allow constructor injection
+
+### Added
+- PHP 8 conform type hinting
+
 ## [[5.0.1] - 2022-05-26](https://github.com/monooso/unobserve/releases/tag/v5.0.1)
 ### Changed
 - Improved documentation, courtesy of [Sergej Tihonov](https://github.com/Sergej-Tihonov)

--- a/src/CanMute.php
+++ b/src/CanMute.php
@@ -4,13 +4,14 @@ namespace Monooso\Unobserve;
 
 trait CanMute
 {
-    public static function mute($events = null)
+    /** @param string|string[] $events */
+    public static function mute(string|array $events = null): void
     {
         $instance = resolve(static::class);
         resolve(ProxyManager::class)->register($instance, static::normalizeEvents($events));
     }
 
-    protected static function normalizeEvents($events): array
+    protected static function normalizeEvents(null|string|array $events): array
     {
         if (is_null($events)) {
             $events = ['*'];
@@ -23,7 +24,7 @@ trait CanMute
         return $events;
     }
 
-    public static function unmute()
+    public static function unmute(): void
     {
         resolve(ProxyManager::class)->unregister(static::class);
     }

--- a/src/CanMute.php
+++ b/src/CanMute.php
@@ -6,7 +6,7 @@ trait CanMute
 {
     public static function mute($events = null)
     {
-        $instance = new static();
+        $instance = resolve(static::class);
         resolve(ProxyManager::class)->register($instance, static::normalizeEvents($events));
     }
 
@@ -25,6 +25,6 @@ trait CanMute
 
     public static function unmute()
     {
-        resolve(ProxyManager::class)->unregister(new static);
+        resolve(ProxyManager::class)->unregister(static::class);
     }
 }

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -6,13 +6,11 @@ use BadMethodCallException;
 
 class Proxy
 {
-    /** @var object */
-    private $target;
+    private object $target;
 
-    /** @var array */
-    private $events;
+    private array $events;
 
-    public function __construct($target, array $events = [])
+    public function __construct(object $target, array $events = [])
     {
         $this->target = $target;
         $this->events = $events;

--- a/src/ProxyManager.php
+++ b/src/ProxyManager.php
@@ -6,22 +6,18 @@ use Illuminate\Container\Container;
 
 class ProxyManager
 {
-    /** @var Container */
-    private $app;
-
-    public function __construct(Container $app)
+    public function __construct(private Container $app)
     {
-        $this->app = $app;
     }
 
-    public function register($target, array $events)
+    public function register(object $target, array $events): void
     {
         $proxy = $this->app->make(Proxy::class, ['target' => $target, 'events' => $events]);
 
         $this->app->instance(get_class($target), $proxy);
     }
 
-    public function unregister(string $targetClass)
+    public function unregister(string $targetClass): void
     {
         $this->app->forgetInstance($targetClass);
     }

--- a/src/ProxyManager.php
+++ b/src/ProxyManager.php
@@ -2,7 +2,7 @@
 
 namespace Monooso\Unobserve;
 
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Container\Container;
 
 class ProxyManager
 {
@@ -21,8 +21,8 @@ class ProxyManager
         $this->app->instance(get_class($target), $proxy);
     }
 
-    public function unregister($target)
+    public function unregister(string $targetClass)
     {
-        $this->app->instance(get_class($target), $target);
+        $this->app->forgetInstance($targetClass);
     }
 }

--- a/src/UnobserveServiceProvider.php
+++ b/src/UnobserveServiceProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Support\ServiceProvider;
 
 class UnobserveServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    public function register()
+    public function register(): void
     {
         parent::register();
 
@@ -20,7 +20,7 @@ class UnobserveServiceProvider extends ServiceProvider implements DeferrableProv
         });
     }
 
-    public function provides()
+    public function provides(): array
     {
         return [ProxyManager::class, Proxy::class];
     }

--- a/tests/CanMuteTest.php
+++ b/tests/CanMuteTest.php
@@ -3,6 +3,7 @@
 namespace Monooso\Unobserve\Tests;
 
 use Monooso\Unobserve\CanMute;
+use Monooso\Unobserve\Proxy;
 use Orchestra\Testbench\TestCase;
 
 class CanMuteTest extends TestCase
@@ -51,6 +52,16 @@ class CanMuteTest extends TestCase
         $this->assertSame('cloaked', $target->cloaked());
         $this->assertSame('uncloaked', $target->uncloaked());
     }
+
+    /** @test */
+    public function it_mutes_class_with_constructor_injection()
+    {
+        WithConstructorInjection::mute();
+
+        $target = resolve(WithConstructorInjection::class);
+
+        $this->assertInstanceOf(Proxy::class, $target);
+    }
 }
 
 class CanMuteTarget
@@ -65,5 +76,14 @@ class CanMuteTarget
     public function uncloaked()
     {
         return 'uncloaked';
+    }
+}
+
+class WithConstructorInjection
+{
+    use CanMute;
+
+    public function __construct(private CanMuteTarget $injection)
+    {
     }
 }

--- a/tests/CanMuteTest.php
+++ b/tests/CanMuteTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase;
 class CanMuteTest extends TestCase
 {
     /** @test */
-    public function it_mutes_an_array_of_events()
+    public function it_mutes_an_array_of_events(): void
     {
         CanMuteTarget::mute(['cloaked']);
 
@@ -20,7 +20,7 @@ class CanMuteTest extends TestCase
     }
 
     /** @test */
-    public function it_mutes_a_single_event()
+    public function it_mutes_a_single_event(): void
     {
         CanMuteTarget::mute('cloaked');
 
@@ -31,7 +31,7 @@ class CanMuteTest extends TestCase
     }
 
     /** @test */
-    public function it_mutes_all_events()
+    public function it_mutes_all_events(): void
     {
         CanMuteTarget::mute();
 
@@ -42,7 +42,7 @@ class CanMuteTest extends TestCase
     }
 
     /** @test */
-    public function it_unmutes_all_events()
+    public function it_unmutes_all_events(): void
     {
         CanMuteTarget::mute();
         CanMuteTarget::unmute();
@@ -54,7 +54,7 @@ class CanMuteTest extends TestCase
     }
 
     /** @test */
-    public function it_mutes_class_with_constructor_injection()
+    public function it_mutes_class_with_constructor_injection(): void
     {
         WithConstructorInjection::mute();
 
@@ -64,7 +64,7 @@ class CanMuteTest extends TestCase
     }
 
     /** @test */
-    public function it_resolves_to_proxy_on_mute()
+    public function it_resolves_to_proxy_on_mute(): void
     {
         CanMuteTarget::mute();
 
@@ -74,7 +74,7 @@ class CanMuteTest extends TestCase
     }
 
     /** @test */
-    public function it_resolves_back_to_class_on_unmute()
+    public function it_resolves_back_to_class_on_unmute(): void
     {
         CanMuteTarget::mute();
         CanMuteTarget::unmute();
@@ -89,12 +89,12 @@ class CanMuteTarget
 {
     use CanMute;
 
-    public function cloaked()
+    public function cloaked(): string
     {
         return 'cloaked';
     }
 
-    public function uncloaked()
+    public function uncloaked(): string
     {
         return 'uncloaked';
     }

--- a/tests/CanMuteTest.php
+++ b/tests/CanMuteTest.php
@@ -62,6 +62,27 @@ class CanMuteTest extends TestCase
 
         $this->assertInstanceOf(Proxy::class, $target);
     }
+
+    /** @test */
+    public function it_resolves_to_proxy_on_mute()
+    {
+        CanMuteTarget::mute();
+
+        $target = resolve(CanMuteTarget::class);
+
+        $this->assertInstanceOf(Proxy::class, $target);
+    }
+
+    /** @test */
+    public function it_resolves_back_to_class_on_unmute()
+    {
+        CanMuteTarget::mute();
+        CanMuteTarget::unmute();
+
+        $target = resolve(CanMuteTarget::class);
+
+        $this->assertInstanceOf(CanMuteTarget::class, $target);
+    }
 }
 
 class CanMuteTarget

--- a/tests/ProxyManagerTest.php
+++ b/tests/ProxyManagerTest.php
@@ -25,7 +25,7 @@ class ProxyManagerTest extends TestCase
         $app = $this->resolveApplication();
 
         $manager = new ProxyManager($app);
-        $manager->unregister(new ProxyManagerTarget);
+        $manager->unregister(ProxyManagerTarget::class);
 
         $this->assertInstanceOf(ProxyManagerTarget::class, $app->make(ProxyManagerTarget::class));
     }

--- a/tests/ProxyManagerTest.php
+++ b/tests/ProxyManagerTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase;
 class ProxyManagerTest extends TestCase
 {
     /** @test */
-    public function it_registers_a_proxy_with_the_service_container()
+    public function it_registers_a_proxy_with_the_service_container(): void
     {
         $app = $this->resolveApplication();
 
@@ -20,7 +20,7 @@ class ProxyManagerTest extends TestCase
     }
 
     /** @test */
-    public function it_unregisters_a_proxy()
+    public function it_unregisters_a_proxy(): void
     {
         $app = $this->resolveApplication();
 

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase;
 class ProxyTest extends TestCase
 {
     /** @test */
-    public function it_swallows_cloaked_events()
+    public function it_swallows_cloaked_events(): void
     {
         $target = new ProxyTarget;
 
@@ -19,7 +19,7 @@ class ProxyTest extends TestCase
     }
 
     /** @test */
-    public function it_passes_uncloaked_events_to_the_observer()
+    public function it_passes_uncloaked_events_to_the_observer(): void
     {
         $target = new ProxyTarget;
 
@@ -29,7 +29,7 @@ class ProxyTest extends TestCase
     }
 
     /** @test */
-    public function it_swallows_all_events()
+    public function it_swallows_all_events(): void
     {
         $target = new ProxyTarget;
         $proxy = new Proxy($target, ['*']);
@@ -39,7 +39,7 @@ class ProxyTest extends TestCase
     }
 
     /** @test */
-    public function it_raises_an_exception_for_unknown_methods()
+    public function it_raises_an_exception_for_unknown_methods(): void
     {
         $target = new ProxyTarget;
 
@@ -51,12 +51,12 @@ class ProxyTest extends TestCase
 
 class ProxyTarget
 {
-    public function uncloaked()
+    public function uncloaked(): string
     {
         return 'uncloaked';
     }
 
-    public function cloaked()
+    public function cloaked(): string
     {
         return 'cloaked';
     }


### PR DESCRIPTION
Hi @monooso ,

I have encountered a problem with constructor injection while using the CanMute trait.
Here is a PR with the change to allow constructor injection on the muted class.

I have split my change in several commits to make the change easier to understand.

1) I have added a unit test to demonstrate the problem 'it_mutes_class_with_constructor_injection'
(you will get an exception here, because of parameter)

2) For the main adjustment:
- Inside the **Mute class**: changed the instantiation from 'new' to 'resolve'
- Inside the **ProxyManager class**:
    - had to change from Container interface to Container class, because the 'forgetInstance' method is not defined in the interface
    - used the 'forgetInstance' method to remove proxy from the container
    - changed 'unregister' method to take directly the target class and not the instance (we can not instantiate because of the injection and we can not resolve, because we would get the proxy class)
    - adjusted the unit test accordingly

3) Added additional unit tests to make sure, that the unmute removed the proxy and returns the muted class
- it_resolves_to_proxy_on_mute
- it_resolves_back_to_class_on_unmute

4) I have added PHP 8 conform type hinting

5) Prepared the changelog for you :v:


If you have any questions or suggestions about my changes let me know.
