### PR TITLE
fix php8.4 deprecation message

### DIFF
--- a/src/CanMute.php
+++ b/src/CanMute.php
@@ -5,7 +5,7 @@ namespace Monooso\Unobserve;
 trait CanMute
 {
     /** @param string|string[] $events */
-    public static function mute(string|array $events = null): void
+    public static function mute(string|array|null $events = null): void
     {
         $instance = resolve(static::class);
         resolve(ProxyManager::class)->register($instance, static::normalizeEvents($events));


### PR DESCRIPTION
implicit null is deprecated from php8.4