### PR TITLE
Include PHP version in Composer cache key

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php-${{ matrix.php }}-
 
       - name: Install package dependencies
         run: composer install --prefer-dist --no-progress


### PR DESCRIPTION
The workflow tests against multiple PHP versions (8.3, 8.4, 8.5), but the Composer cache key did not include the PHP version. This caused all matrix jobs to collide on the same cache key, so a `vendor/` directory built for one PHP version could be restored for a job running a different version.

Include `${{ matrix.php }}` in both the cache key and the restore-keys prefix so each PHP version gets its own cache scope.

Fixes #33.